### PR TITLE
[fix] `getattr_fuse_3`: pass argument `fip` to `fgetattr`.

### DIFF
--- a/mfusepy.py
+++ b/mfusepy.py
@@ -1306,7 +1306,7 @@ class FUSE:
         return self.fgetattr(path, buf, None)
 
     def getattr_fuse_3(self, path: bytes, buf, fip):
-        return self.fgetattr(path, buf, None)
+        return self.fgetattr(path, buf, fip)
 
     def readlink(self, path: bytes, buf, bufsize: int) -> int:
         ret = self.operations.readlink(path.decode(self.encoding)).encode(self.encoding)


### PR DESCRIPTION
`Operations.getattr` may receive a null path, so it should be able to identify the file via the file handle, which it should receive from `FUSE.getattr_fuse_3` via `FUSE.fgetattr`.