### PR TITLE
[CI] Fix FreeBSD job: install pip for the default Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,7 +247,10 @@ jobs:
 
                 # Packages
                 sudo -E pkg update -f
-                sudo -E pkg install -y git fusefs-libs python3 python311 py311-pip
+                # Ports only package pip for the default Python version, which differs between
+                # FreeBSD versions and changes over time, e.g. py311-pip on 13.5 but py312-pip
+                # on 14.3, so install it via its unflavored port origin instead of by name.
+                sudo -E pkg install -y git fusefs-libs python3 devel/py-pip
 
                 # Make FUSE work
                 sudo -E kldload fusefs


### PR DESCRIPTION
The FreeBSD 14.3 job currently fails while installing packages:

```
pkg: No packages available to install matching 'py311-pip' have been found in the repositories
```

Ports only package pip for the *default* Python version, and that default differs between FreeBSD versions and moves over time. Checking the current package indices:

| repository | `python3` meta package pulls in | available pip package |
|---|---|---|
| `FreeBSD:13:amd64/latest` | `python311` | `py311-pip` |
| `FreeBSD:14:amd64/latest` | `python312` | `py312-pip` (no `py311-pip`) |

So the hardcoded `python311 py311-pip` only ever worked by accident and broke when the 14 repository switched its default to 3.12. Since the job runs everything with `python3` anyway, this installs pip via its unflavored port origin `devel/py-pip`, which is unique in both repositories and resolves to the default flavor, so it keeps working when that default moves to 3.13 and later.

The OpenBSD job already uses the version-agnostic `py3-pip` (which does not exist under that name on FreeBSD); the NetBSD job explicitly installs and symlinks `python311` from pkgsrc, which still exists there. Both are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)